### PR TITLE
Common attributes

### DIFF
--- a/test_helpers.py
+++ b/test_helpers.py
@@ -76,8 +76,8 @@ class BasicController():
         if self.view:
             self.view.showSimSelectionList(simStr)
 
-    def saveRiderBtnPress(self, riderID=-1, attributeDict: Dict[str, str] = {}):
-        print(f"rider {riderID} updated:" + str(attributeDict))
+    def saveRiderBtnPress(self, riderID=-1, **kwargs):
+        print(f"rider {riderID} updated:" + str(kwargs))
 
     def saveEnvirBtnPress(self, envirID=-1, attributeDict: Dict[str, str] = {}):
         print(f"environment {envirID} updated:" + str(attributeDict))

--- a/test_helpers.py
+++ b/test_helpers.py
@@ -79,11 +79,11 @@ class BasicController():
     def saveRiderBtnPress(self, riderID=-1, **kwargs):
         print(f"rider {riderID} updated:" + str(kwargs))
 
-    def saveEnvirBtnPress(self, envirID=-1, attributeDict: Dict[str, str] = {}):
-        print(f"environment {envirID} updated:" + str(attributeDict))
+    def saveEnvirBtnPress(self, envirID=-1, **kwargs):
+        print(f"environment {envirID} updated:" + str(kwargs))
 
-    def saveSimBtnPress(self, simID=-1, attributeDict: Dict[str, str] = {}):
-        print(f"simulation {simID} updated:" + str(attributeDict))
+    def saveSimBtnPress(self, simID=-1, **kwargs):
+        print(f"simulation {simID} updated:" + str(kwargs))
 
 def printSuccess(text: str = "success"):
     print(f"{bcolors.OKGREEN}{text}{bcolors.ENDC}")

--- a/test_wottmodel.py
+++ b/test_wottmodel.py
@@ -14,7 +14,7 @@ def test_Rider_valid_attributes() -> int:
             Rider.attributes.CDA: 0.19,
             Rider.attributes.WPRIME: 20
         }
-        rider = Rider(0, attributeDict=attributes)
+        rider = Rider(**attributes)
         printSuccess("test_Rider_valid_attributes")
         return 0
     except:
@@ -33,7 +33,7 @@ def test_Rider_invalid_attributes() -> int:
             Rider.attributes.WPRIME: 20,
             "invalidAttribute": 0
         }
-        rider = Rider(1, attributeDict=attributes)
+        rider = Rider(**attributes)
         printFailure("test_Rider_invalid_attributes")
         return 1
     except AttributeError:
@@ -54,14 +54,14 @@ def test_Rider_getStrAttributeDict() -> int:
             Rider.attributes.CDA: 0.19,
             Rider.attributes.WPRIME: 20
         }
-        rider = Rider(0, attributeDict=attributes)
+        rider = Rider(**attributes)
         strDict = rider.getStrAttributeDict()
-        if all(key in strDict for key in Rider.keyList):
+        if all(key in strDict for key in attributes.keys()):
             printSuccess("test_Rider_getStrAttributeDict")
             return 0
         else:
             raise Exception
-    except:
+    except TabError:
         printFailure("test_Rider_getStrAttributeDict")
         return 1
 
@@ -112,7 +112,7 @@ def test_Environment_getStrAttributeDict() -> int:
         }
         envir = Environment(0, attributeDict=attributes)
         strDict = envir.getStrAttributeDict()
-        if all(key in strDict for key in Environment.keyList):
+        if all(key in strDict for key in attributes.keys()):
             printSuccess("test_Environment_getStrAttributeDict")
             return 0
         else:
@@ -161,16 +161,16 @@ def test_Simulation_getStrAttributeDict() -> int:
             Simulation.attributes.SIMID: 1,
             Simulation.attributes.SIMNAME: "Dave Panams IP",
             Simulation.attributes.RIDER: Rider(0, firstName="David"),
-            Simulation.attributes.ENVIR: Environment(0, envirName="Santiago")
+            Simulation.attributes.ENVIR: Environment(8, envirName="San Juan")
         }
         sim = Simulation(0, attributeDict=attributes)
         strDict = sim.getStrAttributeDict()
-        if all(key in strDict for key in Simulation.keyList):
+        if all(key in strDict for key in attributes.keys()):
             printSuccess("test_Simulation_getStrAttributeDict")
             return 0
         else:
             raise Exception
-    except:
+    except TabError:
         printFailure("test_Simulation_getStrAttributeDict")
         return 1
 

--- a/test_wottmodel.py
+++ b/test_wottmodel.py
@@ -62,7 +62,7 @@ def test_Rider_getStrAttributeDict() -> int:
             return 0
         else:
             raise Exception
-    except TabError:
+    except:
         printFailure("test_Rider_getStrAttributeDict")
         return 1
 
@@ -75,7 +75,7 @@ def test_Environment_valid_attributes() -> int:
             EnvirAttributes.CRR: 0.0015,
             EnvirAttributes.MECHLOSSES: 0.02
         }
-        envir = Environment(0, attributeDict=attributes)
+        envir = Environment(**attributes)
         printSuccess("test_Environment_valid_attributes")
         return 0
     except:
@@ -92,7 +92,7 @@ def test_Environment_invalid_attributes() -> int:
             EnvirAttributes.MECHLOSSES: 0.02,
             "invalidAttribute": 0
         }
-        envir = Environment(0, attributeDict=attributes)
+        envir = Environment(**attributes)
         printFailure("test_Environment_invalid_attributes")
         return 1
     except AttributeError:
@@ -111,7 +111,7 @@ def test_Environment_getStrAttributeDict() -> int:
             EnvirAttributes.CRR: 0.0015,
             EnvirAttributes.MECHLOSSES: 0.02
         }
-        envir = Environment(0, attributeDict=attributes)
+        envir = Environment(**attributes)
         strDict = envir.getStrAttributeDict()
         if all(key in strDict for key in attributes.keys()):
             printSuccess("test_Environment_getStrAttributeDict")
@@ -130,7 +130,7 @@ def test_Simulation_valid_attributes() -> int:
             SimAttributes.RIDER: Rider(0, firstName="David"),
             SimAttributes.ENVIR: Environment(0, envirName="Santiago")
         }
-        sim = Simulation(0, attributeDict=attributes)
+        sim = Simulation(**attributes)
         printSuccess("test_Simulation_valid_attributes")
         return 0
     except:
@@ -146,7 +146,7 @@ def test_Simulation_invalid_attributes() -> int:
             SimAttributes.ENVIR: Environment(0, envirName="Santiago"),
             "invalidAttribute": 0
         }
-        sim = Simulation(0, attributeDict=attributes)
+        sim = Simulation(**attributes)
         printFailure("test_Simulation_invalid_attributes")
         return 1
     except AttributeError:
@@ -164,14 +164,14 @@ def test_Simulation_getStrAttributeDict() -> int:
             SimAttributes.RIDER: Rider(0, firstName="David"),
             SimAttributes.ENVIR: Environment(8, envirName="San Juan")
         }
-        sim = Simulation(0, attributeDict=attributes)
+        sim = Simulation(**attributes)
         strDict = sim.getStrAttributeDict()
         if all(key in strDict for key in attributes.keys()):
             printSuccess("test_Simulation_getStrAttributeDict")
             return 0
         else:
             raise Exception
-    except TabError:
+    except:
         printFailure("test_Simulation_getStrAttributeDict")
         return 1
 

--- a/test_wottmodel.py
+++ b/test_wottmodel.py
@@ -1,18 +1,19 @@
 from wottmodel import *
 from pathlib import Path
 from test_helpers import *
+from wottattributes import *
 
 
 def test_Rider_valid_attributes() -> int:
     try:
         attributes = {
-            Rider.attributes.RIDERID: 1,
-            Rider.attributes.FIRSTNAME: "David",
-            Rider.attributes.LASTNAME: "Domonoske",
-            Rider.attributes.WEIGHT: 90,
-            Rider.attributes.FTP: 380,
-            Rider.attributes.CDA: 0.19,
-            Rider.attributes.WPRIME: 20
+            RiderAttributes.RIDERID: 1,
+            RiderAttributes.FIRSTNAME: "David",
+            RiderAttributes.LASTNAME: "Domonoske",
+            RiderAttributes.WEIGHT: 90,
+            RiderAttributes.FTP: 380,
+            RiderAttributes.CDA: 0.19,
+            RiderAttributes.WPRIME: 20
         }
         rider = Rider(**attributes)
         printSuccess("test_Rider_valid_attributes")
@@ -24,13 +25,13 @@ def test_Rider_valid_attributes() -> int:
 def test_Rider_invalid_attributes() -> int:
     try:
         attributes = {
-            Rider.attributes.RIDERID: 1,
-            Rider.attributes.FIRSTNAME: "David",
-            Rider.attributes.LASTNAME: "Domonoske",
-            Rider.attributes.WEIGHT: 90,
-            Rider.attributes.FTP: 380,
-            Rider.attributes.CDA: 0.19,
-            Rider.attributes.WPRIME: 20,
+            RiderAttributes.RIDERID: 1,
+            RiderAttributes.FIRSTNAME: "David",
+            RiderAttributes.LASTNAME: "Domonoske",
+            RiderAttributes.WEIGHT: 90,
+            RiderAttributes.FTP: 380,
+            RiderAttributes.CDA: 0.19,
+            RiderAttributes.WPRIME: 20,
             "invalidAttribute": 0
         }
         rider = Rider(**attributes)
@@ -46,13 +47,13 @@ def test_Rider_invalid_attributes() -> int:
 def test_Rider_getStrAttributeDict() -> int:
     try:
         attributes = {
-            Rider.attributes.RIDERID: 1,
-            Rider.attributes.FIRSTNAME: "David",
-            Rider.attributes.LASTNAME: "Domonoske",
-            Rider.attributes.WEIGHT: 90,
-            Rider.attributes.FTP: 380,
-            Rider.attributes.CDA: 0.19,
-            Rider.attributes.WPRIME: 20
+            RiderAttributes.RIDERID: 1,
+            RiderAttributes.FIRSTNAME: "David",
+            RiderAttributes.LASTNAME: "Domonoske",
+            RiderAttributes.WEIGHT: 90,
+            RiderAttributes.FTP: 380,
+            RiderAttributes.CDA: 0.19,
+            RiderAttributes.WPRIME: 20
         }
         rider = Rider(**attributes)
         strDict = rider.getStrAttributeDict()
@@ -68,11 +69,11 @@ def test_Rider_getStrAttributeDict() -> int:
 def test_Environment_valid_attributes() -> int:
     try:
         attributes = {
-            Environment.attributes.ENVIRID: 1,
-            Environment.attributes.ENVIRNAME: "Panam Games Santiago",
-            Environment.attributes.AIRDENSITY: "1.105",
-            Environment.attributes.CRR: 0.0015,
-            Environment.attributes.MECHLOSSES: 0.02
+            EnvirAttributes.ENVIRID: 1,
+            EnvirAttributes.ENVIRNAME: "Panam Games Santiago",
+            EnvirAttributes.AIRDENSITY: "1.105",
+            EnvirAttributes.CRR: 0.0015,
+            EnvirAttributes.MECHLOSSES: 0.02
         }
         envir = Environment(0, attributeDict=attributes)
         printSuccess("test_Environment_valid_attributes")
@@ -84,11 +85,11 @@ def test_Environment_valid_attributes() -> int:
 def test_Environment_invalid_attributes() -> int:
     try:
         attributes = {
-            Environment.attributes.ENVIRID: 1,
-            Environment.attributes.ENVIRNAME: "Panam Games Santiago",
-            Environment.attributes.AIRDENSITY: "1.105",
-            Environment.attributes.CRR: 0.0015,
-            Environment.attributes.MECHLOSSES: 0.02,
+            EnvirAttributes.ENVIRID: 1,
+            EnvirAttributes.ENVIRNAME: "Panam Games Santiago",
+            EnvirAttributes.AIRDENSITY: "1.105",
+            EnvirAttributes.CRR: 0.0015,
+            EnvirAttributes.MECHLOSSES: 0.02,
             "invalidAttribute": 0
         }
         envir = Environment(0, attributeDict=attributes)
@@ -104,11 +105,11 @@ def test_Environment_invalid_attributes() -> int:
 def test_Environment_getStrAttributeDict() -> int:
     try:
         attributes = {
-            Environment.attributes.ENVIRID: 1,
-            Environment.attributes.ENVIRNAME: "Panam Games Santiago",
-            Environment.attributes.AIRDENSITY: "1.105",
-            Environment.attributes.CRR: 0.0015,
-            Environment.attributes.MECHLOSSES: 0.02
+            EnvirAttributes.ENVIRID: 1,
+            EnvirAttributes.ENVIRNAME: "Panam Games Santiago",
+            EnvirAttributes.AIRDENSITY: "1.105",
+            EnvirAttributes.CRR: 0.0015,
+            EnvirAttributes.MECHLOSSES: 0.02
         }
         envir = Environment(0, attributeDict=attributes)
         strDict = envir.getStrAttributeDict()
@@ -124,10 +125,10 @@ def test_Environment_getStrAttributeDict() -> int:
 def test_Simulation_valid_attributes() -> int:
     try:
         attributes = {
-            Simulation.attributes.SIMID: 1,
-            Simulation.attributes.SIMNAME: "Dave Panams IP",
-            Simulation.attributes.RIDER: Rider(0, firstName="David"),
-            Simulation.attributes.ENVIR: Environment(0, envirName="Santiago")
+            SimAttributes.SIMID: 1,
+            SimAttributes.SIMNAME: "Dave Panams IP",
+            SimAttributes.RIDER: Rider(0, firstName="David"),
+            SimAttributes.ENVIR: Environment(0, envirName="Santiago")
         }
         sim = Simulation(0, attributeDict=attributes)
         printSuccess("test_Simulation_valid_attributes")
@@ -139,10 +140,10 @@ def test_Simulation_valid_attributes() -> int:
 def test_Simulation_invalid_attributes() -> int:
     try:
         attributes = {
-            Simulation.attributes.SIMID: 1,
-            Simulation.attributes.SIMNAME: "Dave Panams IP",
-            Simulation.attributes.RIDER: Rider(0, firstName="David"),
-            Simulation.attributes.ENVIR: Environment(0, envirName="Santiago"),
+            SimAttributes.SIMID: 1,
+            SimAttributes.SIMNAME: "Dave Panams IP",
+            SimAttributes.RIDER: Rider(0, firstName="David"),
+            SimAttributes.ENVIR: Environment(0, envirName="Santiago"),
             "invalidAttribute": 0
         }
         sim = Simulation(0, attributeDict=attributes)
@@ -158,10 +159,10 @@ def test_Simulation_invalid_attributes() -> int:
 def test_Simulation_getStrAttributeDict() -> int:
     try:
         attributes = {
-            Simulation.attributes.SIMID: 1,
-            Simulation.attributes.SIMNAME: "Dave Panams IP",
-            Simulation.attributes.RIDER: Rider(0, firstName="David"),
-            Simulation.attributes.ENVIR: Environment(8, envirName="San Juan")
+            SimAttributes.SIMID: 1,
+            SimAttributes.SIMNAME: "Dave Panams IP",
+            SimAttributes.RIDER: Rider(0, firstName="David"),
+            SimAttributes.ENVIR: Environment(8, envirName="San Juan")
         }
         sim = Simulation(0, attributeDict=attributes)
         strDict = sim.getStrAttributeDict()

--- a/wottattributes.py
+++ b/wottattributes.py
@@ -25,5 +25,6 @@ class SimAttributes(object):
     SIMNAME = "simName"
     RIDER = "rider"
     ENVIR = "envir"
+    MODEL = "model"
     RIDERLIST = "riderList"
     ENVIRLIST = "envirList"

--- a/wottattributes.py
+++ b/wottattributes.py
@@ -1,0 +1,29 @@
+"""
+Valid attributes for Rider, Environment, and Simulation.
+Model and View are dependent on this, instead of being dependent on each other
+"""
+
+class RiderAttributes(object):
+    RIDERID = "riderID"
+    FIRSTNAME = "firstName"
+    LASTNAME = "lastName"
+    WEIGHT = "weight"
+    FTP = "FTP"
+    WPRIME = "wPrime"
+    CDA = "CdA"
+    POWERRESULTS = "powerResults"
+
+class EnvirAttributes(object):
+    ENVIRID = "envirID"
+    ENVIRNAME = "envirName"
+    AIRDENSITY = "airDensity"
+    CRR = "Crr"
+    MECHLOSSES = "mechLosses"
+
+class SimAttributes(object):
+    SIMID = "simID"
+    SIMNAME = "simName"
+    RIDER = "rider"
+    ENVIR = "envir"
+    RIDERLIST = "riderList"
+    ENVIRLIST = "envirList"

--- a/wottcontroller.py
+++ b/wottcontroller.py
@@ -80,12 +80,12 @@ class Controller(object):
             # show error message
             self.view.showDetailSaveError(error)
 
-    def saveEnvirBtnPress(self, envirID: int=-1, attributeDict: Dict[str, str] = {}):
+    def saveEnvirBtnPress(self, envirID: int=-1, **kwargs):
         # TODO check that the attributes are good?
         envir = self.model.getEnvir(envirID)
 
         try:
-            envir.setProperty(attributeDict)
+            envir.setProperty(**kwargs)
 
             # update the subselection menu in case the name changed
             self.view.showEnvirSelectionList(Controller.replaceEmptyName(self.model.getEnvirNameIDs(), "New Environment"))
@@ -96,12 +96,12 @@ class Controller(object):
             # show error message
             self.view.showDetailSaveError(error)
 
-    def saveSimBtnPress(self, simID: int=-1, attributeDict: Dict[str, str] = {}):
+    def saveSimBtnPress(self, simID: int=-1, **kwargs):
         # TODO check that the attributes are good?
         sim = self.model.getSim(simID)
 
         try:
-            sim.setProperty(attributeDict)
+            sim.setProperty(**kwargs)
 
             # update the subselection menu in case the name changed
             self.view.showSimSelectionList(Controller.replaceEmptyName(self.model.getSimNameIDs(), "New Simulation"))

--- a/wottcontroller.py
+++ b/wottcontroller.py
@@ -64,12 +64,12 @@ class Controller(object):
         self.view.showSimDetail(sim.getID(), sim.getStrAttributeDict())
 
     """ ------ Save Data Callbacks ------ """
-    def saveRiderBtnPress(self, riderID: int=-1, attributeDict: Dict[str, str] = {}):
+    def saveRiderBtnPress(self, riderID: int=-1, **kwargs):
         # TODO check that the attributes are good?
         rider = self.model.getRider(riderID)
 
         try:
-            rider.setProperty(attributeDict)
+            rider.setProperty(**kwargs)
 
             # update the subselection menu in case the name changed
             self.view.showRiderSelectionList(Controller.replaceEmptyName(self.model.getRiderNameIDs(), "New Rider"))

--- a/wottmodel.py
+++ b/wottmodel.py
@@ -24,42 +24,21 @@ class Rider(object):
         CDA = "CdA"
         POWERRESULTS = "powerResults"
 
-    keyList = [
-        attributes.RIDERID,
-        attributes.FIRSTNAME,
-        attributes.LASTNAME,
-        attributes.WEIGHT,
-        attributes.FTP,
-        attributes.WPRIME,
-        attributes.CDA,
-        attributes.POWERRESULTS
-    ]
-
-    def __init__(self,
-                 riderID: int,
-                 firstName: str = "",
-                 lastName: str = "",
-                 weight: float = None,
-                 FTP: float = None,
-                 wPrime: float = None,
-                 CdA: float = None,
-                 powerResults: Dict[float, float] = {},
-                 attributeDict: Dict[str, object] = {}) -> None:
+    def __init__(self, riderID: int, **kwargs) -> None:
+        # init riderID, everything else gets defaults
         self.riderID = riderID
-        self.firstName = firstName
-        self.lastName = lastName
-        self.weight = weight
-        self.FTP = FTP
-        self.wPrime = wPrime
-        self.CdA = CdA
-        self.powerResults = powerResults
+        self.firstName = ""
+        self.lastName = ""
+        self.weight = None
+        self.FTP = None
+        self.wPrime = None
+        self.CdA = None
+        self.powerResults = {}
 
-        if attributeDict:
-            self.setProperty(attributeDict, nullAllowed=True)
+        self.setProperty(nullAllowed=True, **kwargs)
 
-    # TODO check that the values are appropriate type and value
-    # TODO I think there's a more pythonic way to do this, but it works
-    def setProperty(self, attributeDict: Dict[str, object], nullAllowed: bool = False):
+    # TODO do more thorough value checking
+    def setProperty(self, nullAllowed: bool = False, **kwargs):
         # get the current attributes
         tmp_riderID = self.riderID
         tmp_firstName = self.firstName
@@ -70,9 +49,9 @@ class Rider(object):
         tmp_CdA = self.CdA
         tmp_powerResults = self.powerResults
 
-        for attribute, value in attributeDict.items():
+        for keyword, value in kwargs.items():
             try:
-                match attribute:
+                match keyword:
                     case self.attributes.RIDERID:
                         tmp_riderID = int(value)
                     case self.attributes.FIRSTNAME:
@@ -91,9 +70,9 @@ class Rider(object):
                         # TODO parse power results
                         tmp_powerResults = value
                     case _:
-                        raise AttributeError(f"'{attribute}' is not a property of the Rider class")
+                        raise AttributeError(f"'{keyword}' is not a property of the Rider class")
             except (TypeError,ValueError) as e:
-                raise TypeError(f"'{attribute}' entry is not valid")
+                raise TypeError(f"'{keyword}' entry is not valid")
 
         if not (nullAllowed or tmp_firstName or tmp_lastName):
             raise AttributeError("firstName or lastName must be set")
@@ -146,14 +125,6 @@ class Environment(object):
         AIRDENSITY = "airDensity"
         CRR = "Crr"
         MECHLOSSES = "mechLosses"
-
-    keyList = [
-        attributes.ENVIRID,
-        attributes.ENVIRNAME,
-        attributes.AIRDENSITY,
-        attributes.CRR,
-        attributes.MECHLOSSES
-    ]
 
     def __init__(self,
                  envirID: int,
@@ -242,16 +213,6 @@ class Simulation(object):
         RIDERLIST = "riderList"
         ENVIRLIST = "envirList"
         MODEL = "model"
-
-    keyList = [
-        attributes.SIMID,
-        attributes.SIMNAME,
-        attributes.RIDER,
-        attributes.ENVIR,
-        attributes.RIDERLIST,
-        attributes.ENVIRLIST,
-        attributes.MODEL
-    ]
 
     def __init__(self,
                  simID: int,
@@ -551,12 +512,12 @@ class Model(object):
 
     """ ------ Add/Delete methods ------ """
     # add new rider. Returns the new rider
-    def addRider(self, attributeDict: Dict[str, object] = None) -> Rider:
+    def addRider(self, **kwargs) -> Rider:
         # get next riderID from metadata
         riderID = self.metaData.newRiderID()
 
         # make new rider and append to model list
-        rider = Rider(riderID, attributeDict=attributeDict)
+        rider = Rider(riderID, **kwargs)
         self.riders.append(rider)
         # TODO maybe sort the list of riders (or insert above)
 

--- a/wottmodel.py
+++ b/wottmodel.py
@@ -1,6 +1,7 @@
 import pickle
 from typing import List, Dict
 from pathlib import Path
+from wottattributes import *
 
 
 # TODO check file stuff
@@ -13,17 +14,6 @@ metaFile = "meta_data"
 
 """ ------ Rider ------ """
 class Rider(object):
-    # valid keys for setting Rider attributes
-    class attributes:
-        RIDERID = "riderID"
-        FIRSTNAME = "firstName"
-        LASTNAME = "lastName"
-        WEIGHT = "weight"
-        FTP = "FTP"
-        WPRIME = "wPrime"
-        CDA = "CdA"
-        POWERRESULTS = "powerResults"
-
     def __init__(self, riderID: int, **kwargs) -> None:
         # init riderID, everything else gets defaults
         self.riderID = riderID
@@ -52,21 +42,21 @@ class Rider(object):
         for keyword, value in kwargs.items():
             try:
                 match keyword:
-                    case self.attributes.RIDERID:
+                    case RiderAttributes.RIDERID:
                         tmp_riderID = int(value)
-                    case self.attributes.FIRSTNAME:
+                    case RiderAttributes.FIRSTNAME:
                         tmp_firstName = str(value)
-                    case self.attributes.LASTNAME:
+                    case RiderAttributes.LASTNAME:
                         tmp_lastName = str(value)
-                    case self.attributes.WEIGHT:
+                    case RiderAttributes.WEIGHT:
                         tmp_weight = float(value)
-                    case self.attributes.FTP:
+                    case RiderAttributes.FTP:
                         tmp_FTP = float(value)
-                    case self.attributes.WPRIME:
+                    case RiderAttributes.WPRIME:
                         tmp_wPrime = float(value)
-                    case self.attributes.CDA:
+                    case RiderAttributes.CDA:
                         tmp_CdA = float(value)
-                    case self.attributes.POWERRESULTS:
+                    case RiderAttributes.POWERRESULTS:
                         # TODO parse power results
                         tmp_powerResults = value
                     case _:
@@ -105,42 +95,28 @@ class Rider(object):
 
     def getStrAttributeDict(self) -> Dict[str,object]:
         attributes = {
-            Rider.attributes.RIDERID: self.riderID,
-            Rider.attributes.FIRSTNAME: self.firstName,
-            Rider.attributes.LASTNAME: self.lastName,
-            Rider.attributes.WEIGHT: str(self.weight) if self.weight else "",
-            Rider.attributes.FTP: str(self.FTP) if self.FTP else "",
-            Rider.attributes.CDA: str(self.CdA) if self.CdA else "",
-            Rider.attributes.WPRIME: str(self.wPrime) if self.wPrime else "",
-            Rider.attributes.POWERRESULTS: self.powerResults
+            RiderAttributes.RIDERID: self.riderID,
+            RiderAttributes.FIRSTNAME: self.firstName,
+            RiderAttributes.LASTNAME: self.lastName,
+            RiderAttributes.WEIGHT: str(self.weight) if self.weight else "",
+            RiderAttributes.FTP: str(self.FTP) if self.FTP else "",
+            RiderAttributes.CDA: str(self.CdA) if self.CdA else "",
+            RiderAttributes.WPRIME: str(self.wPrime) if self.wPrime else "",
+            RiderAttributes.POWERRESULTS: self.powerResults
         }
         return attributes
 
 """ ------ Environment ------ """
 class Environment(object):
-    # valid keys for setting Rider attributes
-    class attributes:
-        ENVIRID = "envirID"
-        ENVIRNAME = "envirName"
-        AIRDENSITY = "airDensity"
-        CRR = "Crr"
-        MECHLOSSES = "mechLosses"
-
-    def __init__(self,
-                 envirID: int,
-                 envirName: str = "",
-                 airDensity: float = None,
-                 Crr: float = None,
-                 mechLosses: float = None,
-                 attributeDict: Dict[str, object] = {}) -> None:
+    def __init__(self, envirID: int, **kwargs) -> None:
+        # init envirID, everything else gets defaults
         self.envirID = envirID
-        self.envirName = envirName
-        self.airDensity = airDensity
-        self.Crr = Crr
-        self.mechLosses = mechLosses
+        self.envirName = ""
+        self.airDensity = None
+        self.Crr = None
+        self.mechLosses = None
 
-        if attributeDict:
-            self.setProperty(attributeDict, nullAllowed=True)
+        self.setProperty(nullAllowed=True, **kwargs)
 
     # TODO check that the values are appropriate type and value
     # TODO I think there's a more pythonic way to do this, but it works
@@ -155,15 +131,15 @@ class Environment(object):
         for attribute, value in attributeDict.items():
             try:
                 match attribute:
-                    case self.attributes.ENVIRID:
+                    case EnvirAttributes.ENVIRID:
                         tmp_envirID = int(value)
-                    case self.attributes.ENVIRNAME:
+                    case EnvirAttributes.ENVIRNAME:
                         tmp_envirName = str(value)
-                    case self.attributes.AIRDENSITY:
+                    case EnvirAttributes.AIRDENSITY:
                         tmp_airDensity = float(value)
-                    case self.attributes.CRR:
+                    case EnvirAttributes.CRR:
                         tmp_Crr = float(value)
-                    case self.attributes.MECHLOSSES:
+                    case EnvirAttributes.MECHLOSSES:
                         tmp_mechLosses = float(value)
                     case _:
                         raise AttributeError(f"'{attribute}' is not a property of the Environment class")
@@ -195,25 +171,16 @@ class Environment(object):
 
     def getStrAttributeDict(self) -> Dict[str,object]:
         attributes = {
-            Environment.attributes.ENVIRID: self.envirID,
-            Environment.attributes.ENVIRNAME: self.envirName,
-            Environment.attributes.AIRDENSITY: str(self.airDensity) if self.airDensity else "",
-            Environment.attributes.CRR: str(self.Crr) if self.Crr else "",
-            Environment.attributes.MECHLOSSES: str(self.mechLosses) if self.mechLosses else ""
+            EnvirAttributes.ENVIRID: self.envirID,
+            EnvirAttributes.ENVIRNAME: self.envirName,
+            EnvirAttributes.AIRDENSITY: str(self.airDensity) if self.airDensity else "",
+            EnvirAttributes.CRR: str(self.Crr) if self.Crr else "",
+            EnvirAttributes.MECHLOSSES: str(self.mechLosses) if self.mechLosses else ""
         }
         return attributes
 
 """ ------ Simulation ------ """
 class Simulation(object):
-    class attributes:
-        SIMID = "simID"
-        SIMNAME = "simName"
-        RIDER = "rider"
-        ENVIR = "envir"
-        RIDERLIST = "riderList"
-        ENVIRLIST = "envirList"
-        MODEL = "model"
-
     def __init__(self,
                  simID: int,
                  simName: str = "",
@@ -243,11 +210,11 @@ class Simulation(object):
         for attribute, value in attributeDict.items():
             try:
                 match attribute:
-                    case self.attributes.SIMID:
+                    case SimAttributes.SIMID:
                         tmp_simID = int(value)
-                    case self.attributes.SIMNAME:
+                    case SimAttributes.SIMNAME:
                         tmp_simName = str(value)
-                    case self.attributes.RIDER:
+                    case SimAttributes.RIDER:
                         if (type(value)==Rider):
                             tmp_rider = value
                         elif (type(value)==tuple and type(value[1])==int):
@@ -257,7 +224,7 @@ class Simulation(object):
                                 raise ValueError(f"no model to look up rider '{value}'")
                         else:
                             raise TypeError(f"'{attribute}' must be of Rider type")
-                    case self.attributes.ENVIR:
+                    case SimAttributes.ENVIR:
                         if (type(value)==Environment):
                             tmp_envir = value
                         elif (type(value)==tuple and type(value[1])==int):
@@ -267,7 +234,7 @@ class Simulation(object):
                                 raise ValueError(f"no model to look up environment '{value}'")
                         else:
                             raise TypeError(f"'{attribute}' must be of Environment type")
-                    case self.attributes.MODEL:
+                    case SimAttributes.MODEL:
                         if (type(value)==Model):
                             tmp_model = value
                         else:
@@ -320,12 +287,12 @@ class Simulation(object):
 
     def getStrAttributeDict(self) -> Dict[str,object]:
         attributes = {
-            Simulation.attributes.SIMID: self.simID,
-            Simulation.attributes.SIMNAME: self.simName,
-            Simulation.attributes.RIDER: self.rider.getNameID() if self.rider else ("",-1),
-            Simulation.attributes.ENVIR: self.envir.getNameID() if self.envir else ("",-1),
-            Simulation.attributes.RIDERLIST: self.getRiderList(),
-            Simulation.attributes.ENVIRLIST: self.getEnvirList()
+            SimAttributes.SIMID: self.simID,
+            SimAttributes.SIMNAME: self.simName,
+            SimAttributes.RIDER: self.rider.getNameID() if self.rider else ("",-1),
+            SimAttributes.ENVIR: self.envir.getNameID() if self.envir else ("",-1),
+            SimAttributes.RIDERLIST: self.getRiderList(),
+            SimAttributes.ENVIRLIST: self.getEnvirList()
         }
         return attributes
 

--- a/wottmodel.py
+++ b/wottmodel.py
@@ -119,8 +119,7 @@ class Environment(object):
         self.setProperty(nullAllowed=True, **kwargs)
 
     # TODO check that the values are appropriate type and value
-    # TODO I think there's a more pythonic way to do this, but it works
-    def setProperty(self, attributeDict: Dict[str, object], nullAllowed: bool = False):
+    def setProperty(self, nullAllowed: bool = False, **kwargs):
         # get the current attributes
         tmp_envirID = self.envirID
         tmp_envirName = self.envirName
@@ -128,7 +127,7 @@ class Environment(object):
         tmp_Crr = self.Crr
         tmp_mechLosses = self.mechLosses
 
-        for attribute, value in attributeDict.items():
+        for attribute, value in kwargs.items():
             try:
                 match attribute:
                     case EnvirAttributes.ENVIRID:
@@ -181,25 +180,19 @@ class Environment(object):
 
 """ ------ Simulation ------ """
 class Simulation(object):
-    def __init__(self,
-                 simID: int,
-                 simName: str = "",
-                 rider: Rider = None,
-                 envir: Environment = None,
-                 model = None,
-                 attributeDict: Dict[str, object] = {}) -> None:
+    def __init__(self, simID: int, **kwargs) -> None:
         self.simID = simID
-        self.model = model
-        self.simName = simName
-        self.rider = rider
-        self.envir = envir
+        self.simName = ""
+        self.rider = None
+        self.envir = None
+        self.model = None
 
-        if attributeDict:
-            self.setProperty(attributeDict, nullAllowed=True)
+        self.setProperty(nullAllowed=True, **kwargs)
 
         # TODO pacing strategy is a list of something, probably its own object, maybe even its own file
 
-    def setProperty(self, attributeDict: Dict[str, object], nullAllowed: bool = False):
+    # TODO do more thorough value checking
+    def setProperty(self, nullAllowed: bool = False, **kwargs):
         # get the current attributes
         tmp_simID = self.simID
         tmp_simName = self.simName
@@ -207,7 +200,7 @@ class Simulation(object):
         tmp_envir = self.envir
         tmp_model = self.model
 
-        for attribute, value in attributeDict.items():
+        for attribute, value in kwargs.items():
             try:
                 match attribute:
                     case SimAttributes.SIMID:
@@ -491,24 +484,24 @@ class Model(object):
         return rider
 
     # add new environment. Returns the new environment
-    def addEnvironment(self, attributeDict: Dict[str, object] = None) -> Rider:
+    def addEnvironment(self, **kwargs) -> Rider:
         # get next envirID from metadata
         envirID = self.metaData.newEnvirID()
 
         # make new environment and append to model list
-        envir = Environment(envirID, attributeDict=attributeDict)
+        envir = Environment(envirID, **kwargs)
         self.envirs.append(envir)
         # TODO maybe sort the list of environments (or insert above)
 
         return envir
 
     # add new simulation. Returns the new simulation
-    def addSimulation(self, attributeDict: Dict[str, object] = None) -> Simulation:
+    def addSimulation(self, **kwargs) -> Simulation:
         # get next simID from metadata
         simID = self.metaData.newSimID()
 
         # make new simulation and append to model list
-        sim = Simulation(simID, model=self, attributeDict=attributeDict)
+        sim = Simulation(simID, model=self, **kwargs)
         self.sims.append(sim)
         # TODO maybe sort the list of simulations (or insert above)
 

--- a/wottview.py
+++ b/wottview.py
@@ -2,6 +2,7 @@ import tkinter as tk
 import customtkinter as ctk
 from typing import List, Dict, Callable
 from functools import partial
+from wottattributes import *
 
 class View(ctk.CTkFrame):
     def __init__(self, parent):
@@ -254,17 +255,6 @@ class SimSelectFrame(ctk.CTkFrame):
 
 # Rider Profiles main content frame
 class RiderProfileFrame(ctk.CTkFrame):
-    # same as wottmodel.Rider.attributes
-    class attributes:
-        RIDERID = "riderID"
-        FIRSTNAME = "firstName"
-        LASTNAME = "lastName"
-        WEIGHT = "weight"
-        FTP = "FTP"
-        WPRIME = "wPrime"
-        CDA = "CdA"
-        POWERRESULTS = "powerResults"
-
     def __init__(self, parent, controller = None,
                  riderID: int = -1,
                  firstName: str = "",
@@ -357,21 +347,21 @@ class RiderProfileFrame(ctk.CTkFrame):
         for attribute, value in attributeDict.items():
             match attribute:
                 # TODO change all of these to
-                case self.attributes.RIDERID:
+                case RiderAttributes.RIDERID:
                     self.riderID = int(value)
-                case self.attributes.FIRSTNAME:
+                case RiderAttributes.FIRSTNAME:
                     self.firstName = str(value)
-                case self.attributes.LASTNAME:
+                case RiderAttributes.LASTNAME:
                     self.lastName = str(value)
-                case self.attributes.WEIGHT:
+                case RiderAttributes.WEIGHT:
                     self.weight = str(value)
-                case self.attributes.FTP:
+                case RiderAttributes.FTP:
                     self.FTP = str(value)
-                case self.attributes.WPRIME:
+                case RiderAttributes.WPRIME:
                     self.wPrime = str(value)
-                case self.attributes.CDA:
+                case RiderAttributes.CDA:
                     self.CdA = str(value)
-                case self.attributes.POWERRESULTS:
+                case RiderAttributes.POWERRESULTS:
                     self.powerResults = value
                 case _:
                     pass
@@ -388,13 +378,13 @@ class RiderProfileFrame(ctk.CTkFrame):
 
         # send to controller
         if self.controller:
-            attributeDict = {self.attributes.FIRSTNAME: self.firstName,
-                             self.attributes.LASTNAME: self.lastName,
-                             self.attributes.WEIGHT: self.weight,
-                             self.attributes.FTP: self.FTP,
-                             self.attributes.WPRIME: self.wPrime,
-                             self.attributes.CDA: self.CdA,
-                             self.attributes.POWERRESULTS: self.powerResults}
+            attributeDict = {RiderAttributes.FIRSTNAME: self.firstName,
+                             RiderAttributes.LASTNAME: self.lastName,
+                             RiderAttributes.WEIGHT: self.weight,
+                             RiderAttributes.FTP: self.FTP,
+                             RiderAttributes.WPRIME: self.wPrime,
+                             RiderAttributes.CDA: self.CdA,
+                             RiderAttributes.POWERRESULTS: self.powerResults}
 
             self.controller.saveRiderBtnPress(self.riderID, **attributeDict)
 
@@ -412,14 +402,6 @@ class RiderProfileFrame(ctk.CTkFrame):
 
 # Environment Profiles main content frame
 class EnvironmentProfileFrame(ctk.CTkFrame):
-    # same as wottmodel.Environment.attributes
-    class attributes:
-        ENVIRID = "envirID"
-        ENVIRNAME = "envirName"
-        AIRDENSITY = "airDensity"
-        CRR = "Crr"
-        MECHLOSSES = "mechLosses"
-
     def __init__(self, parent, controller = None,
                  envirID: int = -1,
                  envirName: str = "",
@@ -494,15 +476,15 @@ class EnvironmentProfileFrame(ctk.CTkFrame):
         for attribute, value in attributeDict.items():
             match attribute:
                 # TODO change all of these to
-                case self.attributes.ENVIRID:
+                case EnvirAttributes.ENVIRID:
                     self.envirID = int(value)
-                case self.attributes.ENVIRNAME:
+                case EnvirAttributes.ENVIRNAME:
                     self.envirName = str(value)
-                case self.attributes.AIRDENSITY:
+                case EnvirAttributes.AIRDENSITY:
                     self.airDensity = str(value)
-                case self.attributes.CRR:
+                case EnvirAttributes.CRR:
                     self.Crr = str(value)
-                case self.attributes.MECHLOSSES:
+                case EnvirAttributes.MECHLOSSES:
                     self.mechLosses = str(value)
                 case _:
                     pass
@@ -516,10 +498,10 @@ class EnvironmentProfileFrame(ctk.CTkFrame):
 
         # send to controller
         if self.controller:
-            attributeDict = {self.attributes.ENVIRNAME: self.envirName,
-                             self.attributes.AIRDENSITY: self.airDensity,
-                             self.attributes.CRR: self.Crr,
-                             self.attributes.MECHLOSSES: self.mechLosses}
+            attributeDict = {EnvirAttributes.ENVIRNAME: self.envirName,
+                             EnvirAttributes.AIRDENSITY: self.airDensity,
+                             EnvirAttributes.CRR: self.Crr,
+                             EnvirAttributes.MECHLOSSES: self.mechLosses}
 
             self.controller.saveEnvirBtnPress(self.envirID, attributeDict)
 
@@ -537,18 +519,6 @@ class EnvironmentProfileFrame(ctk.CTkFrame):
 
 # Simulation Profiles main content frame
 class SimulationProfileFrame(ctk.CTkFrame):
-    """
-    NOT THE SAME as wottmodel.Simulation.attributes
-    TODO finish this. It's mostly still just copied from EnvironmentProfileFrame
-    """
-    class attributes:
-        SIMID = "simID"
-        SIMNAME = "simName"
-        RIDER = "rider"
-        ENVIR = "envir"
-        RIDERLIST = "riderList"
-        ENVIRLIST = "envirList"
-
     def __init__(self, parent, controller = None,
                  simID: int = -1,
                  simName: str = "",
@@ -613,17 +583,17 @@ class SimulationProfileFrame(ctk.CTkFrame):
         for attribute, value in attributeDict.items():
             match attribute:
                 # TODO change all of these to
-                case self.attributes.SIMID:
+                case SimAttributes.SIMID:
                     self.simID = int(value)
-                case self.attributes.SIMNAME:
+                case SimAttributes.SIMNAME:
                     self.simName = str(value)
-                case self.attributes.RIDER:
+                case SimAttributes.RIDER:
                     self.rider = value
-                case self.attributes.ENVIR:
+                case SimAttributes.ENVIR:
                     self.envir = value
-                case self.attributes.RIDERLIST:
+                case SimAttributes.RIDERLIST:
                     self.riderList = value
-                case self.attributes.ENVIRLIST:
+                case SimAttributes.ENVIRLIST:
                     self.envirList = value
                 case _:
                     pass
@@ -636,9 +606,9 @@ class SimulationProfileFrame(ctk.CTkFrame):
 
         # send to controller
         if self.controller:
-            attributeDict = {self.attributes.SIMNAME: self.simName,
-                             self.attributes.RIDER: self.rider,
-                             self.attributes.ENVIR: self.envir}
+            attributeDict = {SimAttributes.SIMNAME: self.simName,
+                             SimAttributes.RIDER: self.rider,
+                             SimAttributes.ENVIR: self.envir}
 
             self.controller.saveSimBtnPress(self.simID, attributeDict)
 

--- a/wottview.py
+++ b/wottview.py
@@ -503,7 +503,7 @@ class EnvironmentProfileFrame(ctk.CTkFrame):
                              EnvirAttributes.CRR: self.Crr,
                              EnvirAttributes.MECHLOSSES: self.mechLosses}
 
-            self.controller.saveEnvirBtnPress(self.envirID, attributeDict)
+            self.controller.saveEnvirBtnPress(self.envirID, **attributeDict)
 
     """ ------ alert label methods ------ """
     def hideAlert(self):
@@ -610,7 +610,7 @@ class SimulationProfileFrame(ctk.CTkFrame):
                              SimAttributes.RIDER: self.rider,
                              SimAttributes.ENVIR: self.envir}
 
-            self.controller.saveSimBtnPress(self.simID, attributeDict)
+            self.controller.saveSimBtnPress(self.simID, **attributeDict)
 
     """ ------ alert label methods ------ """
     def hideAlert(self):

--- a/wottview.py
+++ b/wottview.py
@@ -396,7 +396,7 @@ class RiderProfileFrame(ctk.CTkFrame):
                              self.attributes.CDA: self.CdA,
                              self.attributes.POWERRESULTS: self.powerResults}
 
-            self.controller.saveRiderBtnPress(self.riderID, attributeDict)
+            self.controller.saveRiderBtnPress(self.riderID, **attributeDict)
 
     """ ------ alert label methods ------ """
     def hideAlert(self):


### PR DESCRIPTION
This is the move of all keyword attributes from the Model and View into a separate `wattattributes.py` file. This file is then referenced from `wottview.py` and `wottmodel.py` and is the one source of truth.

This PR also contains the switch from `attributeDict` to `**kwargs`. It is actually a very similar implementation, but is more pythonic and I think easier to read for somebody coming straight in without knowing what's going on.