### PR TITLE
22 rider and environment lists dont update in simulation view

### DIFF
--- a/wottmodel.py
+++ b/wottmodel.py
@@ -248,6 +248,9 @@ class Simulation(object):
         self.model = tmp_model
 
     """ ------ getters and setters ------ """
+    def setModel(self, model):
+        self.model = model
+
     def setRider(self, rider: Rider):
         self.rider = rider
 
@@ -319,6 +322,10 @@ class Model(object):
         self.storageDir = Path(storageDir)
 
         self.loadModel()
+
+        # update the model stored in sims to self
+        for sim in self.sims:
+            sim.setModel(self)
 
         # TODO should I have a save flag that represents if the data has been changed since it was last saved?
 

--- a/wottmodel.py
+++ b/wottmodel.py
@@ -418,6 +418,10 @@ class Model(object):
         # create application directory if it doesn't exist
         Path(self.storageDir).mkdir(parents=True, exist_ok=True)
 
+        # remove the links to model stored in sims (to save space)
+        for sim in self.sims:
+            sim.model = None
+
         self.saveRiders()
         self.saveEnvirs()
         self.saveSims()


### PR DESCRIPTION
model reference is updated after `pickle.load()`

I'm now thinking that the bigger solution is to remove the reference to the model.
1. the simulation probably shouldn't know about the model because why would it care
2. circular references
3. I only use it to print a list of available riders. What if instead I just have the controller use the model to do that, and then only give the sim the things that it actually needs?